### PR TITLE
Add CSS style sheets with @font-face declarations

### DIFF
--- a/webfonts/blackout_midnight.css
+++ b/webfonts/blackout_midnight.css
@@ -10,7 +10,7 @@
 */
 @font-face {
   font-family: 'Blackout Midnight';
-  src: url('blackout_midnight-webfont.eot'),
+  src: url('blackout_midnight-webfont.eot');
   src: url('blackout_midnight-webfont.eot?#iefix') format('embedded-opentype'),
        url('blackout_midnight-webfont.woff') format('woff'),
        url('blackout_midnight-webfont.ttf')  format('truetype'),

--- a/webfonts/blackout_midnight.css
+++ b/webfonts/blackout_midnight.css
@@ -1,0 +1,17 @@
+/*
+  'Blackout Midnight' (solid style)
+  https://www.theleagueofmoveabletype.com/blackout
+
+  Copyright (c) 2012, Tyler Finck <hello@sursly.com>,
+  with Reserved Font Name: "Blackout".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Blackout Midnight';
+  src: url('blackout_midnight-webfont.eot?#iefix') format('embedded-opentype'),
+       url('blackout_midnight-webfont.woff') format('woff'),
+       url('blackout_midnight-webfont.ttf')  format('truetype'),
+       url('blackout_midnight-webfont.svg#BlackoutMidnight') format('svg');
+}

--- a/webfonts/blackout_midnight.css
+++ b/webfonts/blackout_midnight.css
@@ -10,6 +10,7 @@
 */
 @font-face {
   font-family: 'Blackout Midnight';
+  src: url('blackout_midnight-webfont.eot'),
   src: url('blackout_midnight-webfont.eot?#iefix') format('embedded-opentype'),
        url('blackout_midnight-webfont.woff') format('woff'),
        url('blackout_midnight-webfont.ttf')  format('truetype'),

--- a/webfonts/blackout_sunrise.css
+++ b/webfonts/blackout_sunrise.css
@@ -1,0 +1,17 @@
+/*
+  'Blackout Sunrise' (stroked style)
+  https://www.theleagueofmoveabletype.com/blackout
+
+  Copyright (c) 2012, Tyler Finck <hello@sursly.com>,
+  with Reserved Font Name: "Blackout".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Blackout Sunrise';
+  src: url('blackout_sunrise-webfont.eot?#iefix') format('embedded-opentype'),
+       url('blackout_sunrise-webfont.woff') format('woff'),
+       url('blackout_sunrise-webfont.ttf')  format('truetype'),
+       url('blackout_sunrise-webfont.svg#BlackoutSunrise') format('svg');
+}

--- a/webfonts/blackout_sunrise.css
+++ b/webfonts/blackout_sunrise.css
@@ -10,7 +10,7 @@
 */
 @font-face {
   font-family: 'Blackout Sunrise';
-  src: url('blackout_sunrise-webfont.eot'),
+  src: url('blackout_sunrise-webfont.eot');
   src: url('blackout_sunrise-webfont.eot?#iefix') format('embedded-opentype'),
        url('blackout_sunrise-webfont.woff') format('woff'),
        url('blackout_sunrise-webfont.ttf')  format('truetype'),

--- a/webfonts/blackout_sunrise.css
+++ b/webfonts/blackout_sunrise.css
@@ -10,6 +10,7 @@
 */
 @font-face {
   font-family: 'Blackout Sunrise';
+  src: url('blackout_sunrise-webfont.eot'),
   src: url('blackout_sunrise-webfont.eot?#iefix') format('embedded-opentype'),
        url('blackout_sunrise-webfont.woff') format('woff'),
        url('blackout_sunrise-webfont.ttf')  format('truetype'),

--- a/webfonts/blackout_two_am.css
+++ b/webfonts/blackout_two_am.css
@@ -1,0 +1,17 @@
+/*
+  'Blackout 2AM' (reversed style)
+  https://www.theleagueofmoveabletype.com/blackout
+
+  Copyright (c) 2012, Tyler Finck <hello@sursly.com>,
+  with Reserved Font Name: "Blackout".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Blackout 2AM';
+  src: url('blackout_two_am-webfont.eot?#iefix') format('embedded-opentype'),
+       url('blackout_two_am-webfont.woff') format('woff'),
+       url('blackout_two_am-webfont.ttf')  format('truetype'),
+       url('blackout_two_am-webfont.svg#BlackoutTwoAM') format('svg');
+}

--- a/webfonts/blackout_two_am.css
+++ b/webfonts/blackout_two_am.css
@@ -10,6 +10,7 @@
 */
 @font-face {
   font-family: 'Blackout 2AM';
+  src: url('blackout_two_am-webfont.eot');
   src: url('blackout_two_am-webfont.eot?#iefix') format('embedded-opentype'),
        url('blackout_two_am-webfont.woff') format('woff'),
        url('blackout_two_am-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
